### PR TITLE
Update Data.php

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -13,11 +13,9 @@ class Data{
 
 
     public function __construct(
-        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderFactory,
-        \Magento\Sales\Model\Order $orderData
+        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderFactory
     ){
         $this->_orderFactory = $orderFactory;
-        $this->_order = $orderData;
     }
 
     public function getOrdersCollection($status, $start, $end){


### PR DESCRIPTION
Fixes "Area code is not set" on Magento 2.4.x CE. 

There's still a few object manager calls that should be replaced, but some other day ;)